### PR TITLE
Update loofah gem from 2.0.3 to 2.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    crass (1.0.4)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
@@ -66,7 +67,8 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    loofah (2.0.3)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
@@ -74,12 +76,12 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
     multi_json (1.12.1)
     nio4r (2.0.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.3)
+      mini_portile2 (~> 2.3.0)
     pg (0.20.0)
     puma (3.8.2)
     rack (2.0.1)
@@ -171,4 +173,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.2


### PR DESCRIPTION
* Brakeman medium vulnerability
Confidence: Medium
Category: Cross-Site Scripting
Check: SanitizeMethods
Message: Loofah 2.0.3 is vulnerable (CVE-2018-8048). Upgrade to 2.1.2
File: Gemfile.lock
Line: 69

Reference:
https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md